### PR TITLE
Integrate outputs from new CoastalQ module for delta discharge partitioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Build a Docker image: `docker build -t output .`
 - -i: index to locate continent in JSON file
 - -c: Name of the continent JSON file
 - -r: run type for workflow execution: 'constrained' or 'unconstrained'
-- -m: List of modules to gather output data for: "hivdi", "metroman", "moi", "momma", "neobam", "prediagnostics", "priors", "sad", "sic4dvar", "swot", "validation", "offline"
+- -m: List of modules to gather output data for: "hivdi", "metroman", "moi", "momma", "neobam", "prediagnostics", "priors", "sad", "sic4dvar", "swot", "validation", "offline", "coastalq"
 
 **Execute a Docker container:**
 

--- a/metadata/metadata.json
+++ b/metadata/metadata.json
@@ -4287,5 +4287,97 @@
                 "integer time for consensus Q - seconds since beginning of January 1, 2000"
             ]
         }
+    },
+    "coastal": {
+        "delta_name": {
+            "time": {
+                "long_name": [
+                    "time"
+                ],
+                "standard_name": [
+                    "time"
+                ],
+                "units": [
+                    "seconds since 2000-01-01T00:00:00Z"
+                ],
+                "coverage_content_type": [
+                    "coordinate"
+                ],
+                "calendar": [
+                    "standard"
+                ],
+                "axis": [
+                    "T"
+                ]
+            },
+            "reach": {
+                "long_name": [
+                    "Local Delta Reach ID"
+                ],
+                "comment": [
+                    "Local reach identifiers within the delta network"
+                ],
+                "units": [
+                    "-"
+                ],
+                "coverage_content_type": [
+                    "coordinate"
+                ]
+            },
+            "sword_inlets": {
+                "long_name": [
+                    "SWORD Reach ID"
+                ],
+                "comment": [
+                    "SWORD reach identifiers at delta inlets from which discharge is summed and partitioned"
+                ],
+                "units": [
+                    "-"
+                ],
+                "coverage_content_type": [
+                    "coordinate"
+                ]
+            },
+            "algos": {
+                "long_name": [
+                    "Algorithm Name"
+                ],
+                "comment": [
+                    "Names of discharge algorithms used to compute delta apex discharge"
+                ],
+                "units": [
+                    "-"
+                ],
+                "coverage_content_type": [
+                    "coordinate"
+                ]
+            },
+            "Q": {
+                "standard_name": [
+                    "water_volume_transport_in_river_channel"
+                ],
+                "long_name": [
+                    "River Discharge"
+                ],
+                "comment": [
+                    "Discharge partitioned to delta sub-reaches from apex discharge"
+                ],
+                "units": [
+                    "m3 s-1"
+                ],
+                "valid_min": [
+                    0.0
+                ],
+                "valid_max": [
+                    1000000000.0
+                ],
+                "_FillValue": [
+                    "NaN"
+                ],
+                "coverage_content_type": [
+                    "modelResult"
+                ]
+            }
+        }
     }
 }

--- a/output/Append.py
+++ b/output/Append.py
@@ -30,6 +30,7 @@ import numpy as np
 import xarray as xr
 
 # Local imports
+from output.modules.CoastalQ import CoastalQ
 from output.modules.Consensus import Consensus
 from output.modules.Hivdi import Hivdi
 from output.modules.Metroman import Metroman
@@ -124,7 +125,7 @@ class Append:
         logger: Logger
             logger to use for logging state
         sword_version: str, optional
-            SWORD version number (default: "16")
+            SWORD version number (default: "17")
         """
         
         self.sword_version = sword_version
@@ -231,7 +232,7 @@ class Append:
                 self.logger.error(traceback.format_exc())        
                 
     def create_modules(self, run_type, input_dir, diag_dir, flpe_dir, moi_dir, \
-                       off_dir, val_dir, consensus_dir, lakeflow_dir, ssc_dir):
+                       off_dir, val_dir, consensus_dir, lakeflow_dir, ssc_dir, coastalq_dir):
         
         """Create and stores a list of AbstractModule objects.
         
@@ -334,6 +335,9 @@ class Append:
                         self.sos_nids
                     )
                 )
+            if module == "coastalq":
+                self.modules.append(CoastalQ(list(self.cont.values())[0], \
+                    coastalq_dir, self.sos_file, self.logger))
                 
     def update_time_coverage(self):
         """Update time coverage for results."""

--- a/output/modules/CoastalQ.py
+++ b/output/modules/CoastalQ.py
@@ -1,0 +1,162 @@
+# Standard imports
+from pathlib import Path
+
+# Third-party imports
+from netCDF4 import Dataset
+import numpy as np
+
+# Local imports
+from output.modules.AbstractModule import AbstractModule
+
+
+def detect_continent(inlet_reaches):
+    """
+    Detect continent code from inlet_reaches variable.
+
+    The first digit of the first inlet reach ID corresponds to the continent code.
+
+    Parameters
+    ----------
+    inlet_reaches : np.ndarray
+        Array of inlet reach IDs
+
+    Returns
+    -------
+    int
+        Single digit continent code
+    """
+    first_inlet = int(inlet_reaches[0]) if isinstance(inlet_reaches, (list, np.ndarray)) else int(inlet_reaches)
+    continent_code = int(str(first_inlet)[0])
+    return continent_code
+
+
+class CoastalQ(AbstractModule):
+    """
+    A class that represents the results of running CoastalQ delta discharge partitioning.
+
+    Appends delta discharge data to continent files under nested 'coastal/delta_name' groups.
+    """
+
+    def __init__(self, cont_ids, input_dir, sos_new, logger):
+        """
+        Parameters
+        ----------
+        cont_ids: list
+            list of continent identifiers
+        input_dir: Path
+            path to input directory containing coastalq subdirectory
+        sos_new: Path
+            path to new SOS file
+        logger: logging.Logger
+            logger to use for logging state
+        """
+        # Initialize parent with minimal required attributes
+        self.cont_ids = cont_ids
+        self.input_dir = Path(input_dir)
+        self.sos_new = sos_new
+        self.logger = logger
+
+    def create_data_dict(self):
+        """Creates and returns an empty dictionary to hold file mappings."""
+        return {}
+
+    def get_module_data(self):
+        """Queue CoastalQ delta NetCDF files for the active continent."""
+        cq_dir = self.input_dir / "coastalq"
+        cq_files = list(cq_dir.glob("*.nc"))
+        data_dict = self.create_data_dict()
+
+        if not cq_files:
+            self.logger.info("No CoastalQ delta files found")
+            return data_dict
+
+        for cq_file in cq_files:
+            try:
+                with Dataset(cq_file, 'r') as ds:
+                    continent_code = detect_continent(ds['sword_inlets'][:])
+
+                    # Ensure we only append deltas inside of the currently processing continent(s)
+                    if continent_code not in self.cont_ids:
+                        continue
+
+                    delta_name = cq_file.stem
+                    data_dict[delta_name] = cq_file
+
+                    self.logger.info(f"Queued delta {delta_name} for continent {continent_code}")
+
+            except Exception as e:
+                self.logger.warning(f'Failed to read {cq_file}: {e}')
+
+        return data_dict
+
+    def append_module_data(self, data_dict, metadata_json):
+        """Dynamically copy all contents of the CoastalQ files to the SoS output.
+
+        Parameters
+        ----------
+        data_dict : dict
+            Dictionary mapping delta_name to its source file Path.
+        metadata_json : dict
+            JSON object containing SoS metadata.
+        """
+        if not data_dict:
+            self.logger.info("No CoastalQ data to append for this continent.")
+            return
+
+        # Open the main output file to append coastal data
+        with Dataset(self.sos_new, 'a') as sos_ds:
+
+            # Create or access the 'coastal' root group
+            if 'coastal' not in sos_ds.groups:
+                coastal_group = sos_ds.createGroup('coastal')
+            else:
+                coastal_group = sos_ds.groups['coastal']
+
+            for delta_name, cq_file in data_dict.items():
+                try:
+                    with Dataset(cq_file, 'r') as src_ds:
+                        # Create or access subgroup for this specific delta
+                        if delta_name not in coastal_group.groups:
+                            delta_group = coastal_group.createGroup(delta_name)
+                        else:
+                            delta_group = coastal_group.groups[delta_name]
+
+                        # 1. Copy Group-level Attributes
+                        delta_group.setncatts(src_ds.__dict__)
+
+                        # 2. Copy Dimensions (handling unlimited dimensions safely)
+                        for dim_name, dimension in src_ds.dimensions.items():
+                            if dim_name not in delta_group.dimensions:
+                                delta_group.createDimension(
+                                    dim_name, 
+                                    len(dimension) if not dimension.isunlimited() else None
+                                )
+
+                        # 3. Copy Variables, Variable Attributes, and Data dynamically
+                        for var_name, variable in src_ds.variables.items():
+                            if var_name not in delta_group.variables:
+
+                                # Safely extract _FillValue if it exists to pass to createVariable
+                                fill_value = variable.getncattr('_FillValue') if '_FillValue' in variable.ncattrs() else None
+
+                                out_var = delta_group.createVariable(
+                                    var_name,
+                                    variable.datatype,
+                                    variable.dimensions,
+                                    fill_value=fill_value,
+                                    compression="zlib"
+                                )
+
+                                # Copy all other attributes (excluding _FillValue which is already set)
+                                attrs = {k: variable.getncattr(k) for k in variable.ncattrs() if k != '_FillValue'}
+                                if attrs:
+                                    out_var.setncatts(attrs)
+
+                                # Copy the raw data payload
+                                out_var[:] = variable[:]
+
+                    self.logger.info(f"Successfully appended delta {delta_name} to coastal group")
+
+                except Exception as e:
+                    self.logger.warning(f'Failed to append delta {delta_name}: {e}')
+        return

--- a/output/modules/CoastalQ.py
+++ b/output/modules/CoastalQ.py
@@ -62,8 +62,7 @@ class CoastalQ(AbstractModule):
 
     def get_module_data(self):
         """Queue CoastalQ delta NetCDF files for the active continent."""
-        cq_dir = self.input_dir / "coastalq"
-        cq_files = list(cq_dir.glob("*.nc"))
+        cq_files = list(self.input_dir.glob("*.nc"))
         data_dict = self.create_data_dict()
 
         if not cq_files:
@@ -112,6 +111,7 @@ class CoastalQ(AbstractModule):
             else:
                 coastal_group = sos_ds.groups['coastal']
 
+            coastal_info_set = False # flag
             for delta_name, cq_file in data_dict.items():
                 try:
                     with Dataset(cq_file, 'r') as src_ds:
@@ -121,8 +121,11 @@ class CoastalQ(AbstractModule):
                         else:
                             delta_group = coastal_group.groups[delta_name]
 
-                        # 1. Copy Group-level Attributes
-                        delta_group.setncatts(src_ds.__dict__)
+                        # 1. Copy attributes for the first delta in the series
+                        if not coastal_info_set:
+                            filtered_attrs = {k: v for k, v in src_ds.__dict__.items() if k != 'delta_name'}
+                            coastal_group.setncatts(filtered_attrs)
+                            coastal_info_set = True
 
                         # 2. Copy Dimensions (handling unlimited dimensions safely)
                         for dim_name, dimension in src_ds.dimensions.items():

--- a/run_output.py
+++ b/run_output.py
@@ -39,7 +39,7 @@ CONSENSUS = Path('/mnt/data/flpe')
 OUTPUT = Path("/mnt/data/output")
 LAKEFLOW = Path("/mnt/data/flpe/lakeflow")
 SSC = Path("/mnt/data/flpe/ssc")
-COASTALQ = Path("/mnt/coastalq")
+COASTALQ = Path("/mnt/coastalq") # possibly update to /mnt/data/coastalq
 
 def create_args():
     """Create and return argparser with arguments."""

--- a/run_output.py
+++ b/run_output.py
@@ -39,7 +39,7 @@ CONSENSUS = Path('/mnt/data/flpe')
 OUTPUT = Path("/mnt/data/output")
 LAKEFLOW = Path("/mnt/data/flpe/lakeflow")
 SSC = Path("/mnt/data/flpe/ssc")
-COASTALQ = Path("/mnt/data/coastalq")
+COASTALQ = Path("/mnt/coastalq")
 
 def create_args():
     """Create and return argparser with arguments."""

--- a/run_output.py
+++ b/run_output.py
@@ -39,6 +39,7 @@ CONSENSUS = Path('/mnt/data/flpe')
 OUTPUT = Path("/mnt/data/output")
 LAKEFLOW = Path("/mnt/data/flpe/lakeflow")
 SSC = Path("/mnt/data/flpe/ssc")
+COASTALQ = Path("/mnt/data/coastalq")
 
 def create_args():
     """Create and return argparser with arguments."""
@@ -130,7 +131,7 @@ def main():
         logger, args.metadatajson, args.swordversion)
     append.create_new_version()
     append.create_modules(args.runtype, INPUT, DIAGNOSTICS, FLPE, MOI, OFFLINE, \
-        VALIDATION / "stats", CONSENSUS, LAKEFLOW, SSC)
+        VALIDATION / "stats", CONSENSUS, LAKEFLOW, SSC, COASTALQ)
     append.append_data()
     append.update_time_coverage()
 


### PR DESCRIPTION
Hello!

Our team has a new `Confluence` module under review for this next batch of updates called `CoastalQ`, which is responsible for partitioning SWOT-derived discharge across a collection of pre-processed delta networks. The code for that module can be found in [this repository](https://github.com/passaH2O/coastalQ). 

Pending review/approval of that module, this PR introduces functionality to `Output` for reading and appending the results of that `CoastalQ` module to the appropriate SoS results file. Datasets are originally saved as delta-specific NetCDF files inside a subfolder of `/mnt/`, and these changes essentially append the contents of those files to a `coastal` sub-group of the SoS results file. Because these deltas have not in general been integrated into SWORD yet, they require a somewhat unique organizational structure relative to the other datasets (i.e. organized by delta rather than SWORD reach ID). The current tree structure is: top level > coastal > delta_name > data variables (Q, time, local reach ID, etc). Happy to provide an example output file if that's useful.

Both the `CoastalQ` module and this revised `Output` module have been successfully tested within the `Confluence` pipeline on my local machine using Docker desktop and the [run-confluence-locally](https://github.com/SWOT-Confluence/run-confluence-locally) notebooks. 

If there are any questions or requests for changes please let me know.

_One small implementation note_: When testing on my machine, the coastal portion only executed correctly if I mapped the volume to `-v {mnt_dir}/coastalq:/mnt/coastalq` and used the corresponding path `COASTALQ = Path("/mnt/coastalq")` inside `run_output.py`. I know the other modules add the `/data/` subdirectory to both, but for some reason I couldn't get it to execute correctly when that was included. I'm not sure if that actually matters on your end, I just wanted to note that the docker run command currently expects no `/data/` in the volume path.